### PR TITLE
Take the DB host name and the Redis host name from environment

### DIFF
--- a/docker-links.conf.py
+++ b/docker-links.conf.py
@@ -1,6 +1,12 @@
-postgres = os.getenv('POSTGRES_PORT_5432_TCP_ADDR')
-mysql = os.getenv('MYSQL_PORT_3306_TCP_ADDR')
-if postgres:
+postgresLink = os.getenv('POSTGRES_PORT_5432_TCP_ADDR')
+postgresRemote = os.getenv('SENTRY_POSTGRES_HOST')
+postgresRemotePort = os.getenv('SENTRY_POSTGRES_PORT') or ''
+
+mysqlLink = os.getenv('MYSQL_PORT_3306_TCP_ADDR')
+mysqlRemote = os.getenv('SENTRY_MYSQL_HOST')
+mysqlRemotePort = os.getenv('SENTRY_MYSQL_PORT') or ''
+
+if postgresLink:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -19,14 +25,37 @@ if postgres:
                 or os.getenv('POSTGRES_ENV_POSTGRES_PASSWORD')
                 or ''
             ),
-            'HOST': postgres,
+            'HOST': 'postgres',
             'PORT': '',
             'OPTIONS': {
                 'autocommit': True,
             },
         },
     }
-elif mysql:
+elif postgresRemote:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': (
+                os.getenv('SENTRY_DB_NAME')
+                or 'postgres'
+            ),
+            'USER': (
+                os.getenv('SENTRY_DB_USER')
+                or 'postgres'
+            ),
+            'PASSWORD': (
+                os.getenv('SENTRY_DB_PASSWORD')
+                or ''
+            ),
+            'HOST': postgresRemote,
+            'PORT': postgresRemotePort,
+            'OPTIONS': {
+                'autocommit': True,
+            },
+        },
+    }
+elif mysqlLink:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.mysql',
@@ -46,8 +75,28 @@ elif mysql:
                 or os.getenv('MYSQL_ENV_MYSQL_ROOT_PASSWORD')
                 or ''
             ),
-            'HOST': mysql,
+            'HOST': 'mysql',
             'PORT': '',
+        },
+    }
+elif mysqlRemote:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': (
+                os.getenv('SENTRY_DB_NAME')
+                or ''
+            ),
+            'USER': (
+                os.getenv('SENTRY_DB_USER')
+                or 'root'
+            ),
+            'PASSWORD': (
+                os.getenv('SENTRY_DB_PASSWORD')
+                or ''
+            ),
+            'HOST': mysqlRemote,
+            'PORT': mysqlRemotePort,
         },
     }
 else:
@@ -75,18 +124,32 @@ if memcache:
         }
     }
 
-redis = os.getenv('REDIS_PORT_6379_TCP_ADDR')
-if redis:
+
+redisLink = os.getenv('REDIS_PORT_6379_TCP_ADDR')
+redisRemote = os.getenv('SENTRY_REDIS_HOST')
+redisDb = os.getenv('SENTRY_REDIS_DB') or 0
+if redisRemote:
     SENTRY_BUFFER = 'sentry.buffer.redis.RedisBuffer'
     SENTRY_REDIS_OPTIONS = {
         'hosts': {
-            0: {
-                'host': redis,
+            redisDb: {
+                'host': redisRemote,
                 'port': 6379,
             },
         },
     }
-    BROKER_URL = 'redis://' + redis + ':6379'
+    BROKER_URL = 'redis://' + redisRemote + ':6379'
+elif redisLink:
+    SENTRY_BUFFER = 'sentry.buffer.redis.RedisBuffer'
+    SENTRY_REDIS_OPTIONS = {
+        'hosts': {
+            redisDb: {
+                'host': 'redis',
+                'port': 6379,
+            },
+        },
+    }
+    BROKER_URL = 'redis://redis:6379'
 else:
     raise Exception('Error: REDIS_PORT_6379_TCP_ADDR is undefined, did you forget to `--link` a redis container?')
 

--- a/docker-links.conf.py
+++ b/docker-links.conf.py
@@ -19,7 +19,7 @@ if postgres:
                 or os.getenv('POSTGRES_ENV_POSTGRES_PASSWORD')
                 or ''
             ),
-            'HOST': 'postgres',
+            'HOST': postgres,
             'PORT': '',
             'OPTIONS': {
                 'autocommit': True,
@@ -46,7 +46,7 @@ elif mysql:
                 or os.getenv('MYSQL_ENV_MYSQL_ROOT_PASSWORD')
                 or ''
             ),
-            'HOST': 'mysql',
+            'HOST': mysql,
             'PORT': '',
         },
     }

--- a/docker-links.conf.py
+++ b/docker-links.conf.py
@@ -81,12 +81,12 @@ if redis:
     SENTRY_REDIS_OPTIONS = {
         'hosts': {
             0: {
-                'host': 'redis',
+                'host': redis,
                 'port': 6379,
             },
         },
     }
-    BROKER_URL = 'redis://redis:6379'
+    BROKER_URL = 'redis://' + redis + ':6379'
 else:
     raise Exception('Error: REDIS_PORT_6379_TCP_ADDR is undefined, did you forget to `--link` a redis container?')
 


### PR DESCRIPTION
Taking the DB host name and the Redis host name from environment allows to manually define environment and allows to use other istances for Redis and the DB.
